### PR TITLE
Documentation link error fix 

### DIFF
--- a/apps/Cluster/README.md
+++ b/apps/Cluster/README.md
@@ -79,7 +79,7 @@ The interface is optimized for performance on the Raspberry Pi 5 and suitable fo
      ```
 
 - **Cross-compiling for Raspberry Pi (ARM target)**  
-  For instructions on cross-compiling, see [this README](https://github.com/SEAME-pt/Team2_TheySEAME_Rollin/apps/Cluster/Cross_Compile/README.md)
+  For instructions on cross-compiling, see [this README](Cross_Compile/README.md)
 ---
 ## 6. Conclusion
 This document outlines the structure, requirements, and features of the Qt application designed for the Raspberry Pi 5. It serves as a guide for development, deployment, and future enhancements.

--- a/apps/Cluster/README.md
+++ b/apps/Cluster/README.md
@@ -79,7 +79,7 @@ The interface is optimized for performance on the Raspberry Pi 5 and suitable fo
      ```
 
 - **Cross-compiling for Raspberry Pi (ARM target)**  
-  For instructions on cross-compiling, see [this README](https://github.com/SEAME-pt/Team2_TheySEAME_Rollin/blob/feat/QT/apps/Cluster/Cross_Compile/README.md)
+  For instructions on cross-compiling, see [this README](https://github.com/SEAME-pt/Team2_TheySEAME_Rollin/apps/Cluster/Cross_Compile/README.md)
 ---
 ## 6. Conclusion
 This document outlines the structure, requirements, and features of the Qt application designed for the Raspberry Pi 5. It serves as a guide for development, deployment, and future enhancements.


### PR DESCRIPTION
## Description

the documentation of the cluster app had an error with the cross-compile documentation link

---
## Type of Change

- [x] Documentation
- [ ] Feature
- [x] BugFix
- [ ] Other

---
