### PR TITLE
Added a CMakeLists.txt in the root, to run every CMakeLists.txt that …

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
           name: build-artifact
 
       - name: Unpack build
-        run: tar -xzf build.tar.gz
+        run: mkdir -p build && tar -xzf build.tar.gz -C build
 
       - name: Install runtime dependencies (Qt + xvfb)
         run: |
@@ -77,7 +77,7 @@ jobs:
           name: build-artifact
 
       - name: Unpack build
-        run: tar -xzf build.tar.gz
+        run: mkdir -p build && tar -xzf build.tar.gz -C build
 
       - name: Install runtime dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
       - "develop"
 
 jobs:
-  build:
+  cluster-qt-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -24,70 +24,38 @@ jobs:
             qt6-serialbus-dev \
             qt6-connectivity-dev \
             libgtest-dev \
-            libsocketcan-dev
+            xvfb
 
-      - name: Configure CMake
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Configure CMake (Cluster Qt)
+        run: cmake -S apps/Cluster/tests -B build-cluster -DCMAKE_BUILD_TYPE=Release
 
-      - name: Build
-        run: cmake --build build --config Release
+      - name: Build Cluster Qt tests
+        run: cmake --build build-cluster --config Release
 
-      - name: Pack build directory
-        run: |
-          tar -czf build.tar.gz -C build .
+      - name: Run Cluster Qt tests
+        run: xvfb-run ctest --rerun-failed --output-on-failure --test-dir build-cluster
 
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-artifact
-          path: build.tar.gz
-
-  qtt-tests:
-    needs: build
+  rpi5-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
-          name: build-artifact
+          submodules: 'true'
 
-      - name: Unpack build
-        run: mkdir -p build && tar -xzf build.tar.gz -C build
-
-      - name: Install runtime dependencies (Qt + xvfb)
+      - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            qt6-base-dev \
-            qt6-serialbus-dev \
-            qt6-connectivity-dev \
-            xvfb \
-            cmake
+            cmake \
+            g++ \
+            libgtest-dev
 
-      - name: Run Qt tests only (labelled "Qt")
-        run: xvfb-run ctest --rerun-failed --output-on-failure --test-dir build -L Qt
+      - name: Configure CMake (Raspberry Pi 5)
+        run: cmake -S apps/rpi5-firmware/tests -B build-rpi5 -DCMAKE_BUILD_TYPE=Release
 
-  other-tests:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifact
+      - name: Build Raspberry Pi 5 tests
+        run: cmake --build build-rpi5 --config Release
 
-      - name: Unpack build
-        run: mkdir -p build && tar -xzf build.tar.gz -C build
-
-      - name: Install runtime dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            qt6-base-dev \
-            qt6-serialbus-dev \
-            qt6-connectivity-dev \
-            xvfb \
-            cmake
-
-      - name: Run non-Qt tests (exclude label "Qt")
-        run: ctest --rerun-failed --output-on-failure --test-dir build -LE Qt
+      - name: Run Raspberry Pi 5 tests
+        run: ctest --rerun-failed --output-on-failure --test-dir build-rpi5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,4 +37,4 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Run Tests
-        run: xvfb-run ctest --test-dir build --no-stop-on-failure --output-on-failure
+        run: xvfb-run ctest --test-dir build --continue-on-failure --output-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,4 +37,4 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Run Tests
-        run: xvfb-run ctest --test-dir build
+        run: xvfb-run ctest --rerun-failed --output-on-failure --test-dir build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: 'true'
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
             qt6-serialbus-dev \
             qt6-connectivity-dev \
             libgtest-dev \
-            libsocketcan-dev \  # <--- Add this for the new firmware
+            libsocketcan-dev \
             xvfb
 
       - name: Configure CMake

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,4 +37,4 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Run Tests
-        run: xvfb-run ctest --test-dir build --continue-on-failure --output-on-failure
+        run: xvfb-run ctest --test-dir build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,23 +1,20 @@
 name: C++ CI with Qt6 and GoogleTest
 
-# Trigger the workflow on pushes or pull requests to your main branch
-# and your specific feature branch
 on:
   pull_request:
     branches:
       - "develop"
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: 'true'
 
-      - name: Install Dependencies
+      - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -27,8 +24,7 @@ jobs:
             qt6-serialbus-dev \
             qt6-connectivity-dev \
             libgtest-dev \
-            libsocketcan-dev \
-            xvfb
+            libsocketcan-dev
 
       - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
@@ -36,5 +32,62 @@ jobs:
       - name: Build
         run: cmake --build build --config Release
 
-      - name: Run Tests
-        run: xvfb-run ctest --rerun-failed --output-on-failure --test-dir build
+      - name: Pack build directory
+        run: |
+          tar -czf build.tar.gz -C build .
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact
+          path: build.tar.gz
+
+  qtt-tests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+
+      - name: Unpack build
+        run: tar -xzf build.tar.gz
+
+      - name: Install runtime dependencies (Qt + xvfb)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            qt6-base-dev \
+            qt6-serialbus-dev \
+            qt6-connectivity-dev \
+            xvfb \
+            cmake
+
+      - name: Run Qt tests only (labelled "Qt")
+        run: xvfb-run ctest --rerun-failed --output-on-failure --test-dir build -L Qt
+
+  other-tests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+
+      - name: Unpack build
+        run: tar -xzf build.tar.gz
+
+      - name: Install runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            qt6-base-dev \
+            qt6-serialbus-dev \
+            qt6-connectivity-dev \
+            xvfb \
+            cmake
+
+      - name: Run non-Qt tests (exclude label "Qt")
+        run: ctest --rerun-failed --output-on-failure --test-dir build -LE Qt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,4 +37,4 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Run Tests
-        run: xvfb-run ctest --test-dir build --output-on-failure
+        run: xvfb-run ctest --test-dir build --no-stop-on-failure --output-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
             xvfb
 
       - name: Configure CMake
-        run: cmake -S Team2_TheySEAME_Rollin/ -B build -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
         run: cmake --build build --config Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
             qt6-serialbus-dev \
             qt6-connectivity-dev \
             libgtest-dev \
+            libsocketcan-dev \  # <--- Add this for the new firmware
             xvfb
 
       - name: Configure CMake

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: C++ CI with Qt6 and GoogleTest
+
+# Trigger the workflow on pushes or pull requests to your main branch
+# and your specific feature branch
+on:
+  pull_request:
+    branches:
+      - "develop"
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            g++ \
+            qt6-base-dev \
+            qt6-serialbus-dev \
+            qt6-connectivity-dev \
+            libgtest-dev \
+            xvfb
+
+      - name: Configure CMake
+        run: cmake -S Team2_TheySEAME_Rollin/ -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Run Tests
+        run: xvfb-run ctest --test-dir build --output-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,52 +2,36 @@ name: C++ CI with Qt6 and GoogleTest
 
 on:
   pull_request:
-    branches:
-      - "develop"
+    branches: [ "develop" ]
 
 jobs:
-  # Job 1: Qt-based tests (Requires Xvfb for GUI components)
   cluster-qt-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
-
-      - name: Install Qt and Build Dependencies
+      - name: Install Qt6 & Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            cmake g++ libgtest-dev xvfb \
-            qt6-base-dev qt6-serialbus-dev qt6-connectivity-dev
-
-      - name: Configure and Build
+          sudo apt-get install -y cmake g++ xvfb \
+            qt6-base-dev qt6-test-dev qt6-serialbus-dev qt6-connectivity-dev libgtest-dev
+      - name: Build and Run
         run: |
           cmake -S apps/Cluster/tests -B build-cluster -DCMAKE_BUILD_TYPE=Release
-          cmake --build build-cluster --config Release
+          cmake --build build-cluster
+          xvfb-run ctest --test-dir build-cluster --output-on-failure
 
-      - name: Run Tests
-        run: xvfb-run ctest --rerun-failed --output-on-failure --test-dir build-cluster
-
-  # Job 2: Raspberry Pi Firmware tests (No Qt dependencies needed)
   rpi5-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
-
-      - name: Install Build Dependencies
+      - name: Build and Run
         run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake g++ libgtest-dev
-
-      - name: Configure and Build
-        run: |
+          # No need to install libgtest-dev if you build it from submodules
+          sudo apt-get update && sudo apt-get install -y cmake g++
           cmake -S apps/rpi5-firmware/tests -B build-rpi5 -DCMAKE_BUILD_TYPE=Release
-          cmake --build build-rpi5 --config Release
-
-      - name: Run Tests
-        run: ctest --rerun-failed --output-on-failure --test-dir build-rpi5
+          cmake --build build-rpi5
+          ctest --test-dir build-rpi5 --output-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
       - "develop"
 
 jobs:
+  # Job 1: Qt-based tests (Requires Xvfb for GUI components)
   cluster-qt-tests:
     runs-on: ubuntu-latest
     steps:
@@ -14,27 +15,22 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Install build dependencies
+      - name: Install Qt and Build Dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            cmake \
-            g++ \
-            qt6-base-dev \
-            qt6-serialbus-dev \
-            qt6-connectivity-dev \
-            libgtest-dev \
-            xvfb
+            cmake g++ libgtest-dev xvfb \
+            qt6-base-dev qt6-serialbus-dev qt6-connectivity-dev
 
-      - name: Configure CMake (Cluster Qt)
-        run: cmake -S apps/Cluster/tests -B build-cluster -DCMAKE_BUILD_TYPE=Release
+      - name: Configure and Build
+        run: |
+          cmake -S apps/Cluster/tests -B build-cluster -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-cluster --config Release
 
-      - name: Build Cluster Qt tests
-        run: cmake --build build-cluster --config Release
-
-      - name: Run Cluster Qt tests
+      - name: Run Tests
         run: xvfb-run ctest --rerun-failed --output-on-failure --test-dir build-cluster
 
+  # Job 2: Raspberry Pi Firmware tests (No Qt dependencies needed)
   rpi5-tests:
     runs-on: ubuntu-latest
     steps:
@@ -43,19 +39,15 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Install build dependencies
+      - name: Install Build Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            cmake \
-            g++ \
-            libgtest-dev
+          sudo apt-get install -y cmake g++ libgtest-dev
 
-      - name: Configure CMake (Raspberry Pi 5)
-        run: cmake -S apps/rpi5-firmware/tests -B build-rpi5 -DCMAKE_BUILD_TYPE=Release
+      - name: Configure and Build
+        run: |
+          cmake -S apps/rpi5-firmware/tests -B build-rpi5 -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-rpi5 --config Release
 
-      - name: Build Raspberry Pi 5 tests
-        run: cmake --build build-rpi5 --config Release
-
-      - name: Run Raspberry Pi 5 tests
+      - name: Run Tests
         run: ctest --rerun-failed --output-on-failure --test-dir build-rpi5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,4 +14,5 @@ enable_testing()
 # Add your scattered directories
 # This will look for a CMakeLists.txt inside these folders
 add_subdirectory(apps/Cluster/tests)
+add_subdirectory(apps/rpi5-firmware)
 # add_subdirectory(apps/OtherModule/tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.16)
+project(Team2_Overall_Project LANGUAGES CXX)
+
+#Global Settings
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+#Find Dependencies (Once for everyone)
+find_package(Qt6 REQUIRED COMPONENTS Test Network SerialBus)
+find_package(GTest REQUIRED)
+
+enable_testing()
+
+# Add your scattered directories
+# This will look for a CMakeLists.txt inside these folders
+add_subdirectory(apps/Cluster/tests)
+# add_subdirectory(apps/OtherModule/tests)

--- a/apps/Cluster/tests/CMakeLists.txt
+++ b/apps/Cluster/tests/CMakeLists.txt
@@ -6,9 +6,6 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Test Network SerialBus)
-find_package(GTest REQUIRED)
-
 add_executable(qtAppTests
     cluster_test.cpp
     ../qtApp/src/generalInfo.cpp

--- a/apps/Cluster/tests/CMakeLists.txt
+++ b/apps/Cluster/tests/CMakeLists.txt
@@ -21,4 +21,4 @@ target_link_libraries(qtAppTests
 )
 
 include(GoogleTest)
-gtest_discover_tests(qtAppTests DISCOVERY_LABELS Qt)
+gtest_discover_tests(qtAppTests)

--- a/apps/Cluster/tests/CMakeLists.txt
+++ b/apps/Cluster/tests/CMakeLists.txt
@@ -1,23 +1,26 @@
 cmake_minimum_required(VERSION 3.16)
-
 project(QtAppTests LANGUAGES CXX)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
+# FIX: You must find the packages before linking them
+find_package(Qt6 REQUIRED COMPONENTS Core Test Network SerialBus)
+find_package(GTest REQUIRED)
+
 add_executable(qtAppTests
-    cluster_test.cpp
-    ../qtApp/src/generalInfo.cpp
-    ../qtApp/src/systemInfo.cpp
+        cluster_test.cpp
+        ../qtApp/src/generalInfo.cpp
+        ../qtApp/src/systemInfo.cpp
 )
 
 target_link_libraries(qtAppTests
-    PRIVATE
-    Qt6::Test
-    Qt6::Network
-    Qt6::SerialBus
-    GTest::gtest_main
+        PRIVATE
+        Qt6::Test
+        Qt6::Network
+        Qt6::SerialBus
+        GTest::gtest_main
 )
 
 include(GoogleTest)

--- a/apps/Cluster/tests/CMakeLists.txt
+++ b/apps/Cluster/tests/CMakeLists.txt
@@ -21,4 +21,4 @@ target_link_libraries(qtAppTests
 )
 
 include(GoogleTest)
-gtest_discover_tests(qtAppTests)
+gtest_discover_tests(qtAppTests DISCOVERY_LABELS Qt)

--- a/apps/rpi5-firmware/tests/CMakeLists.txt
+++ b/apps/rpi5-firmware/tests/CMakeLists.txt
@@ -11,12 +11,8 @@ include_directories(PUBLIC
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../libs/googletest/include
 )
 
-include(GoogleTest)
-
 if(CMAKE_CROSSCOMPILING)
 	add_subdirectory(integration)
-	gtest_discover_tests(integration_tests)
 else()
 	add_subdirectory(unit)
-	gtest_discover_tests(unit_tests)
 endif()

--- a/apps/rpi5-firmware/tests/CMakeLists.txt
+++ b/apps/rpi5-firmware/tests/CMakeLists.txt
@@ -5,10 +5,10 @@ project(RaspTests)
 set(INSTALL_GTEST OFF)
 
 # Build googletest
-add_subdirectory(${CMAKE_SOURCE_DIR}/../../libs/googletest ${CMAKE_BINARY_DIR}/googletest)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../libs/googletest ${CMAKE_BINARY_DIR}/googletest)
 
 include_directories(PUBLIC 
-	${CMAKE_SOURCE_DIR}/../../libs/googletest/include
+	${CMAKE_CURRENT_SOURCE_DIR}/../../libs/googletest/include
 )
 
 if(CMAKE_CROSSCOMPILING)

--- a/apps/rpi5-firmware/tests/CMakeLists.txt
+++ b/apps/rpi5-firmware/tests/CMakeLists.txt
@@ -5,10 +5,10 @@ project(RaspTests)
 set(INSTALL_GTEST OFF)
 
 # Build googletest
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../libs/googletest ${CMAKE_BINARY_DIR}/googletest)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../../libs/googletest ${CMAKE_BINARY_DIR}/googletest)
 
 include_directories(PUBLIC 
-	${CMAKE_CURRENT_SOURCE_DIR}/../../libs/googletest/include
+	${CMAKE_CURRENT_SOURCE_DIR}/../../../libs/googletest/include
 )
 
 if(CMAKE_CROSSCOMPILING)

--- a/apps/rpi5-firmware/tests/CMakeLists.txt
+++ b/apps/rpi5-firmware/tests/CMakeLists.txt
@@ -5,7 +5,9 @@ project(RaspTests)
 set(INSTALL_GTEST OFF)
 
 # Build googletest
-add_subdirectory(${CMAKE_SOURCE_DIR}/../../libs/googletest ${CMAKE_BINARY_DIR}/googletest)
+#add_subdirectory(${CMAKE_SOURCE_DIR}/../../libs/googletest ${CMAKE_BINARY_DIR}/googletest)
+find_package(GTest REQUIRED)
+include(GoogleTest)
 
 include_directories(PUBLIC 
 	${CMAKE_SOURCE_DIR}/../../libs/googletest/include

--- a/apps/rpi5-firmware/tests/CMakeLists.txt
+++ b/apps/rpi5-firmware/tests/CMakeLists.txt
@@ -11,8 +11,12 @@ include_directories(PUBLIC
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../libs/googletest/include
 )
 
+include(GoogleTest)
+
 if(CMAKE_CROSSCOMPILING)
 	add_subdirectory(integration)
+	gtest_discover_tests(integration_tests)
 else()
 	add_subdirectory(unit)
+	gtest_discover_tests(unit_tests)
 endif()

--- a/apps/rpi5-firmware/tests/CMakeLists.txt
+++ b/apps/rpi5-firmware/tests/CMakeLists.txt
@@ -5,9 +5,7 @@ project(RaspTests)
 set(INSTALL_GTEST OFF)
 
 # Build googletest
-#add_subdirectory(${CMAKE_SOURCE_DIR}/../../libs/googletest ${CMAKE_BINARY_DIR}/googletest)
-find_package(GTest REQUIRED)
-include(GoogleTest)
+add_subdirectory(${CMAKE_SOURCE_DIR}/../../libs/googletest ${CMAKE_BINARY_DIR}/googletest)
 
 include_directories(PUBLIC 
 	${CMAKE_SOURCE_DIR}/../../libs/googletest/include

--- a/apps/rpi5-firmware/tests/unit/CMakeLists.txt
+++ b/apps/rpi5-firmware/tests/unit/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 
 project(unit_tests)
 
+find_package(GTest REQUIRED)
+
 set(SOURCES
 	RemoteControlTest.cpp
 )
@@ -9,10 +11,10 @@ set(SOURCES
 add_executable(unit_tests ${SOURCES})
 target_include_directories(unit_tests PUBLIC .)
 target_link_libraries(unit_tests
-	PRIVATE
-	gtest
-	gtest_main
-	gmock
-	mode
+		PRIVATE
+		GTest::gtest
+		GTest::gtest_main
+		GTest::gmock
+		mode
 )
 install(TARGETS unit_tests DESTINATION ${RPI_BIN_DIR})

--- a/apps/rpi5-firmware/tests/unit/CMakeLists.txt
+++ b/apps/rpi5-firmware/tests/unit/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 
 project(unit_tests)
 
-find_package(GTest REQUIRED)
-
 set(SOURCES
 	RemoteControlTest.cpp
 )
@@ -11,10 +9,10 @@ set(SOURCES
 add_executable(unit_tests ${SOURCES})
 target_include_directories(unit_tests PUBLIC .)
 target_link_libraries(unit_tests
-		PRIVATE
-		GTest::gtest
-		GTest::gtest_main
-		GTest::gmock
-		mode
+	PRIVATE
+	gtest
+	gtest_main
+	gmock
+	mode
 )
 install(TARGETS unit_tests DESTINATION ${RPI_BIN_DIR})


### PR DESCRIPTION
## Description

This pull request sets up the initial build and test infrastructure for the project, focusing on enabling continuous integration (CI) and centralizing dependency management. The main changes include adding a GitHub Actions workflow for CI, creating a top-level `CMakeLists.txt` for unified configuration and dependency handling, and cleaning up redundant dependency declarations in submodules.

**Continuous Integration Setup:**

* Added `.github/workflows/tests.yml` to configure a GitHub Actions workflow that builds and tests the project on pull requests to the `develop` branch using Qt6 and GoogleTest. This workflow installs dependencies, configures CMake, builds the project, and runs tests in a headless environment.

**Centralized Build Configuration:**

* Introduced a top-level `CMakeLists.txt` to set global CMake settings, manage dependencies (Qt6 and GTest), enable testing, and add subdirectories for module tests, streamlining the build process for all components.

**Codebase Simplification:**

* Removed redundant `find_package` calls for Qt6 and GTest from `apps/Cluster/tests/CMakeLists.txt`, as these are now handled centrally in the top-level `CMakeLists.txt`.
---
## Type of Change

- [ ] Documentation
- [X] Feature
- [ ] BugFix
- [ ] Other

---
