### PR TITLE
Feat/test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
         run: cmake --build build --parallel $(nproc)
 
       - name: Execute Tests
-        # Move into the build directory created in the step above
         working-directory: build
-        run: ctest --output-on-failure
+        run: |
+            # Use chmod to ensure it's executable, then run it directly
+            chmod +x ./qtAppTests
+            ./qtAppTests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
           mkdir build
           cd build
           cmake .. -DBUILD_TESTS=ON
-          make
           make install  # This creates the 'bin' folder inside this 'build' directory
 
       - name: Run Firmware Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,40 +7,50 @@ on:
     branches: [ feat/test-workflow ]
 
 jobs:
-  run-all-tests:
-    name: Build and Run Tests
+  # --- JOB 1: Qt Cluster Tests ---
+  qt-tests:
+    name: Qt Cluster Tests
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout Code
+      - name: Checkout Code with Submodules
         uses: actions/checkout@v4
+        with:
+          submodules: recursive  # Fetches all nested submodules
 
-      - name: Install System Dependencies
+      - name: Install Qt Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            cmake \
-            libgtest-dev \
-            libgl1-mesa-dev \
-            libxkbcommon-dev
+          sudo apt-get install -y build-essential cmake libgtest-dev qt6-base-dev qt6-serialbus-dev
 
-      - name: Install Qt6 Components
+      - name: Configure and Build
         run: |
-          sudo apt-get install -y \
-            qt6-base-dev \
-            qt6-serialbus-dev
+          cmake -S apps/Cluster/tests -B build-qt -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-qt
 
-      - name: Configure CMake
-      # Pointing to the specific path of your CMakeLists.txt
-        run: cmake -S apps/Cluster/tests -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Run Qt Tests
+        working-directory: build-qt
+        run: ./qtAppTests
 
-      - name: Build All Targets
-        run: cmake --build build --parallel $(nproc)
+  # --- JOB 2: RPI Firmware Tests ---
+  firmware-tests:
+    name: RPI5 Firmware Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code with Submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive  # Crucial for 'comms' or 'mode_manager' if they are submodules
 
-      - name: Execute Tests
-        working-directory: build
+      - name: Install Firmware Dependencies
         run: |
-            # Use chmod to ensure it's executable, then run it directly
-            chmod +x ./qtAppTests
-            ./qtAppTests
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libgtest-dev
+
+      - name: Configure and Build
+        run: |
+          cmake -S apps/rpi5-firmware -B build-firmware -DBUILD_TESTS=ON
+          cmake --build build-firmware
+
+      - name: Run Firmware Tests
+        working-directory: build-firmware
+        run: ctest --output-on-failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,13 @@ jobs:
             qt6-serialbus-dev
 
       - name: Configure CMake
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      # Pointing to the specific path of your CMakeLists.txt
+        run: cmake -S apps/Cluster/tests -B build -DCMAKE_BUILD_TYPE=Release
 
       - name: Build All Targets
         run: cmake --build build --parallel $(nproc)
 
       - name: Execute Tests
+        # Move into the build directory created in the step above
         working-directory: build
         run: ctest --output-on-failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,8 @@
 name: Automated Unit Tests
 
 on:
-  push:
-    branches: [ feat/test-workflow ]
   pull_request:
-    branches: [ feat/test-workflow ]
+    branches: [ develop ]
 
 jobs:
   # --- JOB 1: Qt Cluster Tests ---

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,12 +25,11 @@ jobs:
             libgl1-mesa-dev \
             libxkbcommon-dev
 
-      - name: Install Qt6
+      - name: Install Qt6 Components
         run: |
           sudo apt-get install -y \
             qt6-base-dev \
-            qt6-serialbus-dev \
-            qt6-network-auth-dev
+            qt6-serialbus-dev
 
       - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout Code with Submodules
         uses: actions/checkout@v4
         with:
-          submodules: recursive  # Crucial for 'comms' or 'mode_manager' if they are submodules
+          submodules: recursive
 
       - name: Install Firmware Dependencies
         run: |
@@ -47,10 +47,18 @@ jobs:
           sudo apt-get install -y build-essential cmake libgtest-dev
 
       - name: Configure and Build
+        # We perform the build inside the project directory as requested
         run: |
-          cmake -S apps/rpi5-firmware -B build-firmware -DBUILD_TESTS=ON
-          cmake --build build-firmware
+          cd apps/rpi5-firmware
+          mkdir build
+          cd build
+          cmake .. -DBUILD_TESTS=ON
+          make
+          sudo make install
 
       - name: Run Firmware Tests
-        working-directory: build-firmware
-        run: ctest --output-on-failure
+        # Executing the binary from the 'bin' folder created by 'make install'
+        run: |
+          cd apps/rpi5-firmware/bin
+          chmod +x unit_tests
+          ./unit_tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Automated Unit Tests
+
+on:
+  push:
+    branches: [ feat/test-workflow ]
+  pull_request:
+    branches: [ feat/test-workflow ]
+
+jobs:
+  run-all-tests:
+    name: Build and Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            cmake \
+            libgtest-dev \
+            libgl1-mesa-dev \
+            libxkbcommon-dev
+
+      - name: Install Qt6
+        run: |
+          sudo apt-get install -y \
+            qt6-base-dev \
+            qt6-serialbus-dev \
+            qt6-network-auth-dev
+
+      - name: Configure CMake
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build All Targets
+        run: cmake --build build --parallel $(nproc)
+
+      - name: Execute Tests
+        working-directory: build
+        run: ctest --output-on-failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,19 +46,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libgtest-dev
 
-      - name: Configure and Build
-        # We perform the build inside the project directory as requested
+      - name: Build and Install
         run: |
           cd apps/rpi5-firmware
           mkdir build
           cd build
           cmake .. -DBUILD_TESTS=ON
           make
-          sudo make install
+          make install  # This creates the 'bin' folder inside this 'build' directory
 
       - name: Run Firmware Tests
-        # Executing the binary from the 'bin' folder created by 'make install'
         run: |
-          cd apps/rpi5-firmware/bin
+          # The path is relative to the root of the repo
+          cd apps/rpi5-firmware/build/bin
           chmod +x unit_tests
           ./unit_tests


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate unit testing for both the Qt Cluster application and the RPI5 firmware. The workflow ensures that tests are run automatically on pushes and pull requests to the `feat/test-workflow` branch, improving CI coverage and reliability.

**Continuous Integration Workflow Enhancements:**

* Added a `.github/workflows/test.yml` file to define a new GitHub Actions workflow named "Automated Unit Tests" that runs on pushes and pull requests to the `feat/test-workflow` branch.

**Automated Test Jobs:**

* Introduced a "Qt Cluster Tests" job that checks out code (including submodules), installs Qt and build dependencies, builds the Qt test suite, and runs the Qt unit tests.
* Added an "RPI5 Firmware Tests" job that checks out code (including submodules), installs firmware build dependencies, builds the firmware with tests enabled, and runs the firmware unit tests.## Description

---
## Type of Change

- [ ] Documentation
- [X] Feature
- [ ] BugFix
- [ ] Other

---
