### PR TITLE
Feat/test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,32 @@ jobs:
           cd apps/rpi5-firmware/build/bin
           chmod +x unit_tests
           ./unit_tests
+
+    # --- JOB 3: STM32 Ceedling Tests ---
+    stm32-tests:
+      name: STM32 Ceedling Tests
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout Code with Submodules
+          uses: actions/checkout@v4
+          with:
+            submodules: recursive
+
+        - name: Set up Ruby
+          uses: ruby/setup-ruby@v1
+          with:
+            ruby-version: '3.2' # Recommended version for Ceedling
+            bundler-cache: true
+
+        - name: Install ARM Toolchain
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y gcc-arm-none-eabi
+
+        - name: Install Ceedling
+          run: gem install ceedling
+
+        - name: Run Ceedling Tests
+          # Update this path to where your project.yml is located
+          working-directory: apps/stm32-project
+          run: ceedling test:all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,18 +13,15 @@ jobs:
       - name: Checkout Code with Submodules
         uses: actions/checkout@v4
         with:
-          submodules: recursive  # Fetches all nested submodules
-
+          submodules: recursive
       - name: Install Qt Dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libgtest-dev qt6-base-dev qt6-serialbus-dev
-
       - name: Configure and Build
         run: |
           cmake -S apps/Cluster/tests -B build-qt -DCMAKE_BUILD_TYPE=Release
           cmake --build build-qt
-
       - name: Run Qt Tests
         working-directory: build-qt
         run: ./qtAppTests
@@ -38,52 +35,49 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-
       - name: Install Firmware Dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libgtest-dev
-
       - name: Build and Install
         run: |
           cd apps/rpi5-firmware
-          mkdir build
+          mkdir -p build
           cd build
           cmake .. -DBUILD_TESTS=ON
-          make install  # This creates the 'bin' folder inside this 'build' directory
-
+          make
+          make install
       - name: Run Firmware Tests
         run: |
-          # The path is relative to the root of the repo
           cd apps/rpi5-firmware/build/bin
           chmod +x unit_tests
           ./unit_tests
 
-    # --- JOB 3: STM32 Ceedling Tests ---
-    stm32-tests:
-      name: STM32 Ceedling Tests
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout Code with Submodules
-          uses: actions/checkout@v4
-          with:
-            submodules: recursive
+  # --- JOB 3: STM32 Ceedling Tests ---
+  stm32-tests:
+    name: STM32 Ceedling Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code with Submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-        - name: Set up Ruby
-          uses: ruby/setup-ruby@v1
-          with:
-            ruby-version: '3.2' # Recommended version for Ceedling
-            bundler-cache: true
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2' # Recommended version for Ceedling
+          bundler-cache: true
 
-        - name: Install ARM Toolchain
-          run: |
-            sudo apt-get update
-            sudo apt-get install -y gcc-arm-none-eabi
+      - name: Install ARM Toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-none-eabi
 
-        - name: Install Ceedling
-          run: gem install ceedling
+      - name: Install Ceedling
+        run: gem install ceedling
 
-        - name: Run Ceedling Tests
-          # Update this path to where your project.yml is located
-          working-directory: apps/stm32-project
-          run: ceedling test:all
+      - name: Run Ceedling Tests
+        # Update this path to where your project.yml is located
+        working-directory: apps/stm32-project
+        run: ceedling test:all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,5 +79,5 @@ jobs:
 
       - name: Run Ceedling Tests
         # Update this path to where your project.yml is located
-        working-directory: apps/stm32-project
+        working-directory: apps/stm32-firmware/core/tests
         run: ceedling test:all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,5 +79,5 @@ jobs:
 
       - name: Run Ceedling Tests
         # Update this path to where your project.yml is located
-        working-directory: apps/stm32-firmware/core/tests
+        working-directory: apps/stm32-firmware/Core/Tests
         run: ceedling test:all


### PR DESCRIPTION
This pull request updates the `.github/workflows/test.yml` file to improve the CI workflow for testing different components of the project. The main changes include refining existing build steps for clarity and correctness, as well as introducing a new job for running STM32 Ceedling tests.

**Workflow improvements and fixes:**

* Updated the firmware build step to use `mkdir -p build` (which avoids errors if the directory already exists) and separated the `make` and `make install` commands for clarity.
* Removed unnecessary comments and blank lines to streamline the workflow steps. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L16-L27) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L41-R83)

**New test job:**

* Added a new `stm32-tests` job that checks out the code, sets up Ruby, installs the ARM toolchain and Ceedling, and runs unit tests for the STM32 project using Ceedling.## Description

---
## Type of Change

- [ ] Documentation
- [X] Feature
- [ ] BugFix
- [ ] Other

---
