### PR TITLE
Feature/195 action to build the rpi5 code

### DIFF
--- a/.github/workflows/build_rpi5.yml
+++ b/.github/workflows/build_rpi5.yml
@@ -1,0 +1,60 @@
+name: Build_rpi5
+
+on:
+  workflow_dispatch:
+  push:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    env:
+      RPI_PATH: apps/rpi5-firmware
+      BUILD_HOST: build/host
+      BUILD_TARGET: build/target
+
+    steps:
+      - name: Install deps
+        run: sudo apt-get install -y cmake
+
+      - name: Chekout repo
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+          ref: ${{ github.head_ref }}
+
+      - name: Compile rpi5-firmware
+        run: |
+          cmake -S $RPI_PATH -B $BUILD_HOST
+          make install -C $BUILD_HOST
+          cp -r $BUILD_HOST/bin .
+
+      - name: Download sdk
+        id: aglSDK
+        uses: robinraju/release-downloader@v1
+        with:
+          preRelease: true
+          tag: "SDK"
+          filename: "*.sh"
+
+      - name: Run sdk
+        run: bash ${{ fromJson(steps.aglSDK.outputs.downloaded_files)[0] }} -yd sdk
+
+      - name: Compile rpi5-firmware
+        run: |
+          source sdk/environment-setup-aarch64-agl-linux
+          cmake -S $RPI_PATH -B $BUILD_TARGET
+          make install -C $BUILD_TARGET
+          cp -r $BUILD_TARGET/bin .
+
+      - name: Create github release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: rpi5
+          name: RPI5
+          files: |
+            bin/CarControl
+            bin/unit_tests
+

--- a/.github/workflows/build_rpi5.yml
+++ b/.github/workflows/build_rpi5.yml
@@ -2,7 +2,10 @@ name: Build_rpi5
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'apps/rpi5-firmware/**'
 
 permissions:
   contents: write

--- a/.github/workflows/build_rpi5.yml
+++ b/.github/workflows/build_rpi5.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: true
           ref: ${{ github.head_ref }}
 
-      - name: Compile rpi5-firmware
+      - name: Compile rpi5-firmware for Host (unit_tests)
         run: |
           cmake -S $RPI_PATH -B $BUILD_HOST
           make install -C $BUILD_HOST
@@ -45,7 +45,7 @@ jobs:
       - name: Run sdk
         run: bash ${{ fromJson(steps.aglSDK.outputs.downloaded_files)[0] }} -yd sdk
 
-      - name: Compile rpi5-firmware
+      - name: Compile rpi5-firmware for Target (RPI5)
         run: |
           source sdk/environment-setup-aarch64-agl-linux
           cmake -S $RPI_PATH -B $BUILD_TARGET


### PR DESCRIPTION
## Description

Added a github action that builds the rpi5 code and creates a new release with the built binaries.
The CarControl binary is for the rpi5 (target) to run. The unit_tests binary is to run in our pcs
This is a bit hard-coded but for now it works.

---
## Type of Change

- [ ] Documentation
- [X] Feature
- [ ] BugFix
- [ ] Other

---
