### PR TITLE
Add gRPC and Protobuf dependencies to Qt test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,15 @@ jobs:
       - name: Install Qt Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libgtest-dev qt6-base-dev qt6-serialbus-dev
+          sudo apt-get install -y \
+            build-essential \
+            cmake \
+            libgtest-dev \
+            qt6-base-dev \
+            qt6-serialbus-dev \
+            libgrpc++-dev \
+            libprotobuf-dev \
+            protobuf-compiler-grpc
       - name: Configure and Build
         run: |
           cmake -S apps/Cluster/tests -B build-qt -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
## Description
This pull request updates the workflow dependencies in the GitHub Actions test configuration to include additional libraries required for gRPC and Protocol Buffers support.

Dependency updates:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L20-R28): Added `libgrpc++-dev`, `libprotobuf-dev`, and `protobuf-compiler-grpc` to the list of installed packages to support gRPC and Protocol Buffers in the test environment.

---
## Type of Change

- [ ] Documentation
- [ ] Feature
- [X] BugFix
- [ ] Other

---
