### PR TITLE
Fix title and footer links in requirements viewer HTML for accuracy

### DIFF
--- a/scripts/OFT/requirements_viewer.html
+++ b/scripts/OFT/requirements_viewer.html
@@ -152,7 +152,7 @@
 </head>
 <body>
   <header>
-    <h1>Requirements & OpenFASGT Trace Viewer</h1>
+    <h1>Requirements & OpenFAST Trace Viewer</h1>
     <p>Browse and explore requirements and traceability information in a modern UI</p>
   </header>
   <div class="container">
@@ -175,7 +175,7 @@
     </div>
   </div>
   <footer>
-    <span>Powered by <a href="https://github.com/OpenFASGT" target="_blank">OpenFASGT Trace</a> | Team2_TheySEAME_Rollin</span>
+    <span>Powered by <a href="https://github.com/OpenFAST" target="_blank">OpenFAST Trace</a> | Team2_TheySEAME_Rollin</span>
   </footer>
   <script>
     // Utility: Extract requirements grouped by doctype


### PR DESCRIPTION
## Description
This pull request corrects the project and organization name from "OpenFASGT" to "OpenFAST" in the `requirements_viewer.html` file to ensure proper branding and accurate links.

Branding and link corrections:

* Updated the main header in `requirements_viewer.html` to display "OpenFAST" instead of "OpenFASGT".
* Changed the footer link and text to point to the correct "OpenFAST" GitHub organization.

---
## Type of Change

- [ ] Documentation
- [ ] Feature
- [X] BugFix
- [ ] Other

---
