### PR TITLE
Add qt6-positioning-dev to test workflow dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,8 @@ jobs:
             qt6-serialbus-dev \
             libgrpc++-dev \
             libprotobuf-dev \
-            protobuf-compiler-grpc
+            protobuf-compiler-grpc \
+            qt6-positioning-dev
       - name: Configure and Build
         run: |
           cmake -S apps/Cluster/tests -B build-qt -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
## Description
This pull request makes a minor update to the test workflow configuration by adding a new package dependency to the list of installed packages. This change ensures that the required development files for Qt6 Positioning are available during the build process.

- Added `qt6-positioning-dev` to the list of packages installed in the test workflow to support Qt6 Positioning features.

---
## Type of Change

- [ ] Documentation
- [ ] Feature
- [X] BugFix
- [ ] Other

---
