### PR TITLE
Add gRPC dependency to qtAppTests CMakeLists

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,8 @@ jobs:
             libgrpc++-dev \
             libprotobuf-dev \
             protobuf-compiler-grpc \
-            qt6-positioning-dev
+            qt6-positioning-dev \
+            qt6-location-dev
       - name: Configure and Build
         run: |
           cmake -S apps/Cluster/tests -B build-qt -DCMAKE_BUILD_TYPE=Release

--- a/apps/Cluster/tests/CMakeLists.txt
+++ b/apps/Cluster/tests/CMakeLists.txt
@@ -8,11 +8,16 @@ set(CMAKE_AUTOUIC ON)
 
 find_package(Qt6 REQUIRED COMPONENTS Test Network SerialBus)
 find_package(GTest REQUIRED)
-
+find_package(gRPC CONFIG REQUIRED)
 add_executable(qtAppTests
     cluster_test.cpp
     ../qtApp/src/generalInfo.cpp
     ../qtApp/src/systemInfo.cpp
+)
+
+target_include_directories(qtAppTests PRIVATE
+        "../qtApp/src"
+        "../../middleware"
 )
 
 target_link_libraries(qtAppTests
@@ -21,6 +26,7 @@ target_link_libraries(qtAppTests
     Qt6::Network
     Qt6::SerialBus
     GTest::gtest_main
+    gRPC::grpc++
 )
 
 include(GoogleTest)


### PR DESCRIPTION
## Description
This pull request updates the test build configuration for the `qtAppTests` target, mainly to add support for gRPC and to ensure the correct include directories are set. The most important changes are:

**Dependency and Linking Updates:**
* Added `gRPC` as a required package and linked `gRPC::grpc++` to the `qtAppTests` target, enabling gRPC-based functionality in the tests.

**Build Configuration Improvements:**
* Added `../qtApp/src` and `../../middleware` to the include directories for `qtAppTests` to ensure all necessary headers are available during compilation.

---
## Type of Change

- [ ] Documentation
- [ ] Feature
- [X] BugFix
- [ ] Other

---
