### PR TITLE
Added distance sensor

### DIFF
--- a/apps/stm32-firmware/.gitignore
+++ b/apps/stm32-firmware/.gitignore
@@ -1,6 +1,7 @@
 Debug/**/*.o
 Debug/**/*.d
 Debug/**/*.su
+Debug/**/*.cyclo
 Debug/*.elf
 Debug/*.map
 Debug/*.list

--- a/apps/stm32-firmware/Core/Src/Sensors/distance.c
+++ b/apps/stm32-firmware/Core/Src/Sensors/distance.c
@@ -1,0 +1,34 @@
+#include "sensors.h"
+#include <stdio.h>
+
+void Distance_Thread_Entry(ULONG thread_input)
+{
+    uint16_t distance = 0;
+    uint8_t light = 0;
+    uint8_t buffer[4];
+    char msg[64];
+
+    while (1)
+    {
+        uint8_t cmd = 0x51;
+        HAL_I2C_Mem_Write(&hi2c2, 0xE0, 0x00, 1, &cmd, 1, 100);
+    
+        tx_thread_sleep(70); 
+
+        if(HAL_I2C_Mem_Read(&hi2c2, 0xE0, 0x00, 1, buffer, 4, 100) == HAL_OK)
+        {
+            light = buffer[0]; 
+            distance = (buffer[2] << 8) | buffer[3];
+
+            sprintf(msg, "[DIST] %d cm | [LIGHT] %d\r\n", distance, light);
+            
+            Debug_Print(msg); 
+        }
+        else 
+        {
+            Debug_Print("[Distance THREAD] Error!\r\n");
+        }
+
+        tx_thread_sleep(200);
+    }
+}

--- a/apps/stm32-firmware/Core/Src/app_threadx.c
+++ b/apps/stm32-firmware/Core/Src/app_threadx.c
@@ -50,6 +50,7 @@ TX_THREAD speed_thread;
 TX_THREAD sensors_proc_thread;
 TX_THREAD test_thread;
 TX_THREAD control_thread;
+TX_THREAD distance_thread;
 
 UCHAR sensors_proc_thread_stack[2048];
 UCHAR test_thread_stack[2048];
@@ -57,6 +58,7 @@ UCHAR speed_thread_stack[2048];
 UCHAR battery_thread_stack[2048];
 UCHAR communication_thread_stack[2048];
 UCHAR control_thread_stack[2048];
+UCHAR distance_thread_stack[2048];
 
 extern void Battery_Thread_Entry(ULONG thread_input);
 extern void Communication_Thread_Entry(ULONG thread_input);
@@ -64,7 +66,7 @@ extern void Control_Thread_Entry(ULONG thread_input);
 extern void Test_Thread_Entry(ULONG thread_input);
 extern void Speed_Thread_Entry(ULONG thread_input);
 extern void SensorsProcessor_Thread_Entry(ULONG thread_input);
-
+extern void Distance_Thread_Entry(ULONG thread_input);
 
 /* Global vehicle data and mutex */
 VehicleData_t g_vehicle_data;
@@ -179,6 +181,14 @@ UINT App_ThreadX_Init(VOID *memory_ptr)
   status = tx_thread_create(&speed_thread, "Speed Thread",
                                   Speed_Thread_Entry, 0,
                                   speed_thread_stack, sizeof(speed_thread_stack),
+                                  14, 14, TX_NO_TIME_SLICE, TX_AUTO_START);
+  if (status != TX_SUCCESS) {
+      return TX_THREAD_ERROR;
+  }
+
+  status = tx_thread_create(&distance_thread, "Distance Thread",
+                                  Distance_Thread_Entry, 0,
+                                  distance_thread_stack, sizeof(distance_thread_stack),
                                   14, 14, TX_NO_TIME_SLICE, TX_AUTO_START);
   if (status != TX_SUCCESS) {
       return TX_THREAD_ERROR;

--- a/apps/stm32-firmware/Debug/Core/Src/Sensors/subdir.mk
+++ b/apps/stm32-firmware/Debug/Core/Src/Sensors/subdir.mk
@@ -6,18 +6,21 @@
 # Add inputs and outputs from these tool invocations to the build variables 
 C_SRCS += \
 ../Core/Src/Sensors/battery.c \
+../Core/Src/Sensors/distance.c \
 ../Core/Src/Sensors/sensors_processor.c \
 ../Core/Src/Sensors/sensors_queue.c \
 ../Core/Src/Sensors/speed.c 
 
 OBJS += \
 ./Core/Src/Sensors/battery.o \
+./Core/Src/Sensors/distance.o \
 ./Core/Src/Sensors/sensors_processor.o \
 ./Core/Src/Sensors/sensors_queue.o \
 ./Core/Src/Sensors/speed.o 
 
 C_DEPS += \
 ./Core/Src/Sensors/battery.d \
+./Core/Src/Sensors/distance.d \
 ./Core/Src/Sensors/sensors_processor.d \
 ./Core/Src/Sensors/sensors_queue.d \
 ./Core/Src/Sensors/speed.d 
@@ -30,7 +33,7 @@ Core/Src/Sensors/%.o Core/Src/Sensors/%.su Core/Src/Sensors/%.cyclo: ../Core/Src
 clean: clean-Core-2f-Src-2f-Sensors
 
 clean-Core-2f-Src-2f-Sensors:
-	-$(RM) ./Core/Src/Sensors/battery.cyclo ./Core/Src/Sensors/battery.d ./Core/Src/Sensors/battery.o ./Core/Src/Sensors/battery.su ./Core/Src/Sensors/sensors_processor.cyclo ./Core/Src/Sensors/sensors_processor.d ./Core/Src/Sensors/sensors_processor.o ./Core/Src/Sensors/sensors_processor.su ./Core/Src/Sensors/sensors_queue.cyclo ./Core/Src/Sensors/sensors_queue.d ./Core/Src/Sensors/sensors_queue.o ./Core/Src/Sensors/sensors_queue.su ./Core/Src/Sensors/speed.cyclo ./Core/Src/Sensors/speed.d ./Core/Src/Sensors/speed.o ./Core/Src/Sensors/speed.su
+	-$(RM) ./Core/Src/Sensors/battery.cyclo ./Core/Src/Sensors/battery.d ./Core/Src/Sensors/battery.o ./Core/Src/Sensors/battery.su ./Core/Src/Sensors/distance.cyclo ./Core/Src/Sensors/distance.d ./Core/Src/Sensors/distance.o ./Core/Src/Sensors/distance.su ./Core/Src/Sensors/sensors_processor.cyclo ./Core/Src/Sensors/sensors_processor.d ./Core/Src/Sensors/sensors_processor.o ./Core/Src/Sensors/sensors_processor.su ./Core/Src/Sensors/sensors_queue.cyclo ./Core/Src/Sensors/sensors_queue.d ./Core/Src/Sensors/sensors_queue.o ./Core/Src/Sensors/sensors_queue.su ./Core/Src/Sensors/speed.cyclo ./Core/Src/Sensors/speed.d ./Core/Src/Sensors/speed.o ./Core/Src/Sensors/speed.su
 
 .PHONY: clean-Core-2f-Src-2f-Sensors
 

--- a/apps/stm32-firmware/Debug/objects.list
+++ b/apps/stm32-firmware/Debug/objects.list
@@ -6,6 +6,7 @@
 "./Core/Src/Drivers/ina219.o"
 "./Core/Src/Drivers/pca9685.o"
 "./Core/Src/Sensors/battery.o"
+"./Core/Src/Sensors/distance.o"
 "./Core/Src/Sensors/sensors_processor.o"
 "./Core/Src/Sensors/sensors_queue.o"
 "./Core/Src/Sensors/speed.o"


### PR DESCRIPTION
## Description
This pull request introduces a new distance sensor thread to the STM32 firmware, enabling periodic I2C-based distance and light measurements, and integrates this thread into the ThreadX RTOS initialization.


---
## Type of Change

- [ ] Documentation
- [X] Feature
- [ ] BugFix
- [ ] Other

---
